### PR TITLE
added docker-compose for local development environment (and README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Washeuteessen API
+
+## Starting a development enviroment
+
+### Prerequisits
+
+ * Java 8
+ * Maven 3
+ * Docker (including docker-compose)
+
+### Starting
+
+```bash                                      
+# start support services for development (e.g. database)
+docker-compose up -d
+
+# run the application in development mode
+mvn spring-boot:run                     
+```                                     
+
+### Stopping support services
+
+```bash
+# stop support services (keeping their state)
+docker-compose stop
+       
+# remove support services (deleting there state)
+docker-compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  db:
+    image: "postgres:11"
+    ports:
+      - "5432:5432"

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,8 +8,7 @@ spring:
             indexBase: ./index
             directory_provider: filesystem
   datasource:
-    url: jdbc:postgresql://docker.local:5432/washeuteessen
-    password: password
+    url: jdbc:postgresql://localhost:5432/postgres
     username: postgres
   flyway:
     baseline-on-migrate: true


### PR DESCRIPTION
Added a simple README and a docker-compose file for local development (currently only used to start a postgres database as container).

I needed to change the application-local.yml in order to use this postgres instance as default (host "docker.local" is not available in all scenarios - e.g. developing in linux)